### PR TITLE
Remove file log handler from default values

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 appVersion: latest
 description: A Matrix-Signal puppeting bridge.
 name: mautrix-signal
-version: 0.0.7
+version: 0.0.8
 keywords:
   - synapse
   - chat
@@ -17,11 +17,10 @@ maintainers:
     email: helm@gavinmogan.com
 annotations:
   artifacthub.io/changes: |
-    - "Migrate to new signald app/image"
-    - "Enable signald's metrics"
-  artifacthub.io/containsSecurityUpdates: "false"
+    - "Latest signald (which should fix log4shell)"
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/images: |
     - name: mautrix-signal
       image: dock.mau.dev/mautrix/signal:latest
     - name: signald
-      image: signald/signald:amd64-4d18e1e3a816e98a304f522ae393cde565638273
+      image: signald/signald:amd64-7354fec1d4233224e6827869f64d95ea06981205

--- a/values.yaml
+++ b/values.yaml
@@ -11,7 +11,7 @@ image:
     pullPolicy: Always
   signald:
     repository: signald/signald
-    tag: amd64-4d18e1e3a816e98a304f522ae393cde565638273
+    tag: amd64-7354fec1d4233224e6827869f64d95ea06981205
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/values.yaml
+++ b/values.yaml
@@ -253,12 +253,6 @@ config:
       normal:
         format: "[%(asctime)s] [%(levelname)s@%(name)s] %(message)s"
     handlers:
-      file:
-        class: logging.handlers.RotatingFileHandler
-        formatter: normal
-        filename: ./mautrix-signal.log
-        maxBytes: 10485760
-        backupCount: 10
       console:
         class: logging.StreamHandler
         formatter: colored
@@ -269,7 +263,7 @@ config:
         level: INFO
     root:
       level: DEBUG
-      handlers: [file, console]
+      handlers: [ console ]
 
 registration:
   id: signal


### PR DESCRIPTION
While this can be disabled by the user, I don't think it should be in the default values as it will cause the deployment to fail if `runAsUser` or `readOnlyRootFilesystem` is set and it doesn't make very much sense in a Kubernetes context anyway.