### PR TITLE
improve helm-chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.4.3
 description: A Matrix-Signal puppeting bridge.
 name: mautrix-signal
-version: 0.2.1
+version: 0.3.0
 type: application
 keywords:
   - synapse

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: latest
+appVersion: 0.4.3
 description: A Matrix-Signal puppeting bridge.
 name: mautrix-signal
-version: 0.2.0
+version: 0.2.1
 type: application
 keywords:
   - synapse
@@ -21,6 +21,6 @@ annotations:
   artifacthub.io/containsSecurityUpdates: 'false'
   artifacthub.io/images: |
     - name: mautrix-signal
-      image: "dock.mau.dev/mautrix/signal:latest"
+      image: "dock.mau.dev/mautrix/signal:v0.4.3"
     - name: signald
       image: "signald/signald:0.23.2"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -78,6 +78,11 @@ spec:
             - name: http
               containerPort: {{ required "need config.appservice.port" .Values.config.appservice.port }}
               protocol: TCP
+            {{- if .Values.config.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.config.metrics.listen_port }}
+              protocol: TCP
+            {{- end }}
           {{- with .Values.probes.liveness }}
           livenessProbe:
             httpGet:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -5,23 +5,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mautrix-signal.fullname" . }}
-  {{- if .Values.deploymentAnnotations }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
-    {{- range $key, $value := .Values.deploymentAnnotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-{{ include "mautrix-signal.labels" . | indent 4 }}
+    {{- include "mautrix-signal.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
-{{- if .Values.strategy }}
+  {{- if .Values.strategy }}
   strategy:
-{{ toYaml .Values.strategy | indent 4 }}
-{{ if eq .Values.strategy.type "Recreate" }}
+    {{- toYaml .Values.strategy | nindent 4 }}
+    {{- if eq .Values.strategy.type "Recreate" }}
     rollingUpdate: null
-{{- end }}
-{{- end }}
+    {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mautrix-signal.selectorLabels" . | nindent 6 }}
@@ -29,27 +27,28 @@ spec:
     metadata:
       labels:
         {{- include "mautrix-signal.selectorLabels" . | nindent 8 }}
-      {{- if $podAnnotations }}
-      annotations:
-        {{- range $key, $value := $podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with $podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-    {{- with .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       serviceAccountName: {{ template "mautrix-signal.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.dnsConfig }}
+      {{- with .Values.dnsConfig }}
       dnsConfig:
-        {{- toYaml .Values.dnsConfig | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
         - name: init
-          image: "{{ .Values.image.mautrixSignal.repository }}:{{ tpl .Values.image.mautrixSignal.tag . }}"
+          image: "{{ .Values.image.mautrixSignal.registry }}/{{ .Values.image.mautrixSignal.repository }}:{{ .Values.image.mautrixSignal.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.mautrixSignal.pullPolicy }}
           command: ["/bin/sh"]
           args:
@@ -73,35 +72,39 @@ spec:
         - name: mautrix-signal
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.mautrixSignal.repository }}:{{ tpl .Values.image.mautrixSignal.tag . }}"
+          image: "{{ .Values.image.mautrixSignal.registry }}/{{ .Values.image.mautrixSignal.repository }}:{{ .Values.image.mautrixSignal.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.mautrixSignal.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ required "need config.appservice.port" .Values.config.appservice.port }}
               protocol: TCP
-          env:
-            []
+          {{- with .Values.probes.liveness }}
           livenessProbe:
             httpGet:
               path: /_matrix/mau/live
               port: http
-            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
-            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+            periodSeconds: {{ .periodSeconds }}
+          {{- end }}
+          {{- with .Values.probes.readiness }}
           readinessProbe:
             httpGet:
               path: /_matrix/mau/live
               port: http
-            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
-            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+            failureThreshold: {{ .failureThreshold }}
+            periodSeconds: {{ .periodSeconds }}
+          {{- end }}
+          {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+          {{- with .Values.probes.startup }}
           startupProbe:
             httpGet:
               path: /_matrix/mau/live
               port: http
-            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
-            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
-            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
-{{- end }}
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            failureThreshold: {{ .failureThreshold }}
+            periodSeconds: {{ .periodSeconds }}
+          {{- end }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /config
@@ -114,7 +117,7 @@ spec:
         - name: signald
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.signald.repository }}:{{ tpl .Values.image.signald.tag . }}"
+          image: "{{ .Values.image.signald.registry }}/{{ .Values.image.signald.repository }}:{{ .Values.image.signald.tag }}"
           imagePullPolicy: {{ .Values.image.signald.pullPolicy }}
           args:
             # user socket
@@ -155,11 +158,11 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -14,6 +14,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.config.metrics.enabled }}
+    - port: {{ .Values.config.metrics.listen_port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "mautrix-signal.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.prometheus.servicemonitor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mautrix-signal.fullname" . }}
+  labels:
+    {{- include "mautrix-signal.labels" . | nindent 4 }}
+    {{- with .Values.prometheus.servicemonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      path: /metrics
+  selector:
+    matchLabels:
+      {{- include "mautrix-signal.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -6,12 +6,15 @@ replicaCount: 1
 
 image:
   mautrixSignal:
-    repository: dock.mau.dev/mautrix/signal
-    tag: "{{ .Chart.AppVersion }}"
-    pullPolicy: Always
+    registry: dock.mau.dev
+    repository: mautrix/signal
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+    pullPolicy: IfNotPresent
   signald:
+    registry: docker.io
     repository: signald/signald
-    tag: 0.23.0
+    tag: 0.23.2
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -388,6 +391,7 @@ tolerations: []
 affinity: {}
 
 podAnnotations: {}
+podLabels: {}
 
 deploymentAnnotations: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -412,3 +412,8 @@ persistence:
   size: 1Gi
   ## persistence.skipuninstall -- Do not delete the pvc upon helm uninstall
   skipuninstall: false
+
+prometheus:
+  servicemonitor:
+    enabled: false
+    labels: {}


### PR DESCRIPTION
commit `feat: update image, cleaning code`:
- update signald to 0.23.2
- use AppVersion and tag (with pullPolicy IfNotPresent)
- split registry and repository
- add podLabel
- syntax / cleanup

commit `feat(metrics): forward port`:
- add pod port for metrics (if enabled)
- add service port for metrics (if enabled)

commit `feat(metrics): add servicemonitor`:
- add servicemonitor for prometheus-operator.dev